### PR TITLE
feat: add wallet tables and supabase types

### DIFF
--- a/app/src/integrations/supabase/types.ts
+++ b/app/src/integrations/supabase/types.ts
@@ -733,6 +733,67 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      },
+      wallet_clients: {
+        Row: {
+          created_at: string | null
+          document: string
+          id: string
+          wallet_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          document: string
+          id?: string
+          wallet_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          document?: string
+          id?: string
+          wallet_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wallet_clients_wallet_id_fkey"
+            columns: ["wallet_id"]
+            isOneToOne: false
+            referencedRelation: "wallets"
+            referencedColumns: ["id"]
+          },
+        ]
+      },
+      wallets: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          tenant_id: string | null
+          type: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          tenant_id?: string | null
+          type?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          tenant_id?: string | null
+          type?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wallets_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {

--- a/app/supabase/migrations/20250910220130_03e4471b-ba2d-4e06-a17c-76a5fcd1fa8c.sql
+++ b/app/supabase/migrations/20250910220130_03e4471b-ba2d-4e06-a17c-76a5fcd1fa8c.sql
@@ -1,0 +1,14 @@
+create table wallets (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  type text check (type in ('CPF','CNPJ')),
+  tenant_id uuid references tenants(id),
+  created_at timestamptz default now()
+);
+
+create table wallet_clients (
+  id uuid primary key default uuid_generate_v4(),
+  wallet_id uuid references wallets(id) on delete cascade,
+  document text not null,
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add `wallets` and `wallet_clients` tables to Supabase migrations
- extend generated Supabase types with wallet structures

## Testing
- `supabase gen types typescript --project-dir app/src/integrations/supabase` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 13 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f4b1b74c83218dd0afdbd58449e9