### PR TITLE
feat: dataset pricing and selection pages

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,6 +23,8 @@ import Contratos from "./pages/app/Contratos";
 import ConsultaCPF from "./pages/app/ConsultaCPF";
 import Dashboards from "./pages/app/Dashboards";
 import Integracoes from "./pages/app/Integracoes";
+import Consultas from "./pages/app/Consultas";
+import ConsultasPrecos from "./pages/app/ConsultasPrecos";
 
 // Portal Routes
 import PortalHome from "./routes/portal/PortalHome";
@@ -57,6 +59,8 @@ const App = () => (
             <Route path="/app/clientes" element={<AppLayout><Clientes /></AppLayout>} />
             <Route path="/app/contratos" element={<AppLayout><Contratos /></AppLayout>} />
             <Route path="/app/consultas/cpf" element={<AppLayout><ConsultaCPF /></AppLayout>} />
+            <Route path="/app/consultas" element={<AppLayout><Consultas /></AppLayout>} />
+            <Route path="/app/consultas/precos" element={<AppLayout><ConsultasPrecos /></AppLayout>} />
             <Route path="/app/dashboards" element={<AppLayout><Dashboards /></AppLayout>} />
             <Route path="/app/integracoes" element={<AppLayout><Integracoes /></AppLayout>} />
             <Route path="/app/admin" element={<AppLayout><AdminPanel /></AppLayout>} />

--- a/app/src/integrations/supabase/types.ts
+++ b/app/src/integrations/supabase/types.ts
@@ -279,6 +279,33 @@ export type Database = {
           },
         ]
       }
+      datasets: {
+        Row: {
+          id: string
+          code: string
+          name: string
+          type: string
+          price: number
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          code: string
+          name: string
+          type: string
+          price: number
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          code?: string
+          name?: string
+          type?: string
+          price?: number
+          created_at?: string | null
+        }
+        Relationships: []
+      }
       persons: {
         Row: {
           cpf: string

--- a/app/src/pages/app/Consultas.tsx
+++ b/app/src/pages/app/Consultas.tsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import { supabase } from "@/integrations/supabase/client";
+
+interface Dataset {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  price: number;
+}
+
+export default function Consultas() {
+  const [clientType, setClientType] = useState<string>();
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadDatasets = async () => {
+      if (!clientType) return;
+      const { data } = await supabase
+        .from("datasets")
+        .select("*")
+        .eq("type", clientType);
+      setDatasets(data ?? []);
+    };
+    loadDatasets();
+  }, [clientType]);
+
+  const toggleDataset = (id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((d) => d !== id) : [...prev, id]
+    );
+  };
+
+  const total = datasets
+    .filter((d) => selected.includes(d.id))
+    .reduce((sum, d) => sum + d.price, 0);
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Consultas</h1>
+          <p className="text-muted-foreground mt-2">
+            Selecione o tipo de cliente e os datasets desejados
+          </p>
+        </div>
+        <Button variant="link" asChild>
+          <Link to="/app/consultas/precos">Tabela de preços</Link>
+        </Button>
+      </div>
+
+      <Card variant="elevated">
+        <CardHeader>
+          <CardTitle>Tipo de cliente</CardTitle>
+          <CardDescription>
+            Escolha o tipo de cliente para listar datasets disponíveis
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Select value={clientType} onValueChange={setClientType}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Selecione" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cpf">CPF</SelectItem>
+              <SelectItem value="cnpj">CNPJ</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {clientType && (
+            <div className="space-y-4">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead />
+                    <TableHead>Dataset</TableHead>
+                    <TableHead>Preço (R$)</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {datasets.map((dataset) => (
+                    <TableRow key={dataset.id}>
+                      <TableCell>
+                        <Checkbox
+                          checked={selected.includes(dataset.id)}
+                          onCheckedChange={() => toggleDataset(dataset.id)}
+                        />
+                      </TableCell>
+                      <TableCell>{dataset.name}</TableCell>
+                      <TableCell>{dataset.price.toFixed(2)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="flex justify-end font-semibold">
+                Total: R$ {total.toFixed(2)}
+              </div>
+              <Button disabled={selected.length === 0}>Realizar consulta</Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/src/pages/app/ConsultasPrecos.tsx
+++ b/app/src/pages/app/ConsultasPrecos.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { supabase } from "@/integrations/supabase/client";
+
+interface Dataset {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  price: number;
+}
+
+export default function ConsultasPrecos() {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.from("datasets").select("*");
+      setDatasets(data ?? []);
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold">Tabela de preços</h1>
+        <p className="text-muted-foreground mt-2">
+          Lista completa de datasets e pacotes de preços
+        </p>
+      </div>
+
+      <Card variant="elevated">
+        <CardHeader>
+          <CardTitle>Datasets disponíveis</CardTitle>
+          <CardDescription>Consulta de valores unitários</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Dataset</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Preço (R$)</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {datasets.map((ds) => (
+                <TableRow key={ds.id}>
+                  <TableCell>{ds.name}</TableCell>
+                  <TableCell className="uppercase">{ds.type}</TableCell>
+                  <TableCell>{ds.price.toFixed(2)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card variant="elevated">
+        <CardHeader>
+          <CardTitle>Pacotes de preços</CardTitle>
+          <CardDescription>
+            Combinações de datasets com valores promocionais
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">Em breve.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/supabase/migrations/20250909060000_648a0e55-4484-4087-b0cd-9de2e6b6f346.sql
+++ b/app/supabase/migrations/20250909060000_648a0e55-4484-4087-b0cd-9de2e6b6f346.sql
@@ -1,0 +1,14 @@
+-- Create datasets table
+CREATE TABLE IF NOT EXISTS public.datasets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text UNIQUE NOT NULL,
+  name text NOT NULL,
+  type text NOT NULL CHECK (type IN ('cpf','cnpj')),
+  price numeric(10,2) NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Seed basic datasets
+INSERT INTO public.datasets (code, name, type, price) VALUES
+  ('owners_lawsuits_distribution_data','Distribuicao de processos dos socios','cnpj', 10.00),
+  ('cpf_basic_data','Dados basicos do CPF','cpf',5.00);


### PR DESCRIPTION
## Summary
- add routes and pages to select datasets and view pricing table
- seed Supabase with datasets metadata
- expose datasets types in Supabase types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, missing dependencies, forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f4c53ba88321ba4ccbd2b46091ab