### PR TITLE
Log CNPJ consultations and add history link

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -21,6 +21,7 @@ import Dossie from "./pages/app/Dossie";
 import Clientes from "./pages/app/Clientes";
 import Contratos from "./pages/app/Contratos";
 import ConsultaCPF from "./pages/app/ConsultaCPF";
+import Consultas from "./pages/app/Consultas";
 import Dashboards from "./pages/app/Dashboards";
 import Integracoes from "./pages/app/Integracoes";
 
@@ -57,6 +58,7 @@ const App = () => (
             <Route path="/app/clientes" element={<AppLayout><Clientes /></AppLayout>} />
             <Route path="/app/contratos" element={<AppLayout><Contratos /></AppLayout>} />
             <Route path="/app/consultas/cpf" element={<AppLayout><ConsultaCPF /></AppLayout>} />
+            <Route path="/app/consultas" element={<AppLayout><Consultas /></AppLayout>} />
             <Route path="/app/dashboards" element={<AppLayout><Dashboards /></AppLayout>} />
             <Route path="/app/integracoes" element={<AppLayout><Integracoes /></AppLayout>} />
             <Route path="/app/admin" element={<AppLayout><AdminPanel /></AppLayout>} />

--- a/app/src/pages/app/Consultas.tsx
+++ b/app/src/pages/app/Consultas.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Link } from "react-router-dom";
+
+export default function Consultas() {
+  const [cnpj, setCnpj] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const handleConsulta = async () => {
+    try {
+      const resp = await fetch(`/api/public/cnpj?cnpj=${encodeURIComponent(cnpj)}`);
+      if (resp.ok) {
+        setSuccess(true);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold">Consultas</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Consulta CNPJ</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Digite o CNPJ"
+            value={cnpj}
+            onChange={(e) => setCnpj(e.target.value)}
+          />
+          <Button onClick={handleConsulta}>Consultar</Button>
+          {success && (
+            <p className="text-sm text-green-600">
+              Consulta realizada com sucesso.{' '}
+              <Link to="/app/consultas/historico" className="underline">
+                Ver histórico
+              </Link>
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/supabase/migrations/20250909043000_421117a0-d846-492c-b45c-db515a4ee017.sql
+++ b/app/supabase/migrations/20250909043000_421117a0-d846-492c-b45c-db515a4ee017.sql
@@ -1,0 +1,12 @@
+-- Create consultations table for storing CNPJ lookup results
+CREATE TABLE public.consultations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id uuid REFERENCES public.wallets(id),
+  dataset text NOT NULL,
+  document text NOT NULL,
+  result jsonb,
+  requested_at timestamptz DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE public.consultations ENABLE ROW LEVEL SECURITY;

--- a/prototipo_saas_sabusiness/api.py
+++ b/prototipo_saas_sabusiness/api.py
@@ -31,6 +31,22 @@ def cnpj_lookup(request: HttpRequest):
             "tipo": d.get("natureza_juridica") or d.get("tipo") or "—",
             "situacao": d.get("descricao_situacao_cadastral") or d.get("situacao") or "—",
         }
+        # registra consulta no Supabase (ignora falhas)
+        try:
+            import datetime as dt
+            from utils import supabase_sso as sso
+            sso.upsert(
+                "consultations",
+                {
+                    "wallet_id": request.GET.get("wallet_id"),
+                    "dataset": "cnpj",
+                    "document": digits,
+                    "result": data,
+                    "requested_at": dt.datetime.utcnow().isoformat() + "Z",
+                },
+            )
+        except Exception:
+            pass
         return _ok(data)
     except Exception:
         return _fail("Erro ao consultar serviço público", 502)


### PR DESCRIPTION
## Summary
- add Supabase migration creating `consultations` table
- log CNPJ lookup responses in Supabase
- show confirmation and history link in new Consultas page

## Testing
- `python manage.py test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c1f4c94e0c8321968cf84d764989de